### PR TITLE
OGP画像のURLを絶対パスに修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@
     <meta property="og:title" content="FF14討滅戦タイトル風画面ジェネレーター">
     <meta property="og:description" content="Final Fantasy XIV風の討滅戦タイトル画面を簡単に作成できるツールです。カスタムテキストと背景画像で、あなただけのタイトル画面を生成しましょう。">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="">
-    <meta property="og:image" content="./ogp-image.jpg">
+    <meta property="og:url" content="https://nozomingway.github.io/ffxiv-trial-title-generator/">
+    <meta property="og:image" content="https://nozomingway.github.io/ffxiv-trial-title-generator/ogp-image.jpg">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:site_name" content="FF14討滅戦タイトル風画面ジェネレーター">
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="FF14討滅戦タイトル風画面ジェネレーター">
     <meta name="twitter:description" content="Final Fantasy XIV風の討滅戦タイトル画面を簡単に作成できるツールです。カスタムテキストと背景画像で、あなただけのタイトル画面を生成しましょう。">
-    <meta name="twitter:image" content="./ogp-image.jpg">
+    <meta name="twitter:image" content="https://nozomingway.github.io/ffxiv-trial-title-generator/ogp-image.jpg">
     <meta name="twitter:image:alt" content="FF14風タイトル画面のプレビュー">
     
     <!-- 一般的なメタタグ -->


### PR DESCRIPTION
OGP画像が表示されない問題を修正しました。

## 変更内容
- `og:url`に正しいURLを設定
- `og:image`と`twitter:image`のパスを相対パスから絶対URLに修正
  - 変更前: `./ogp-image.jpg`
  - 変更後: `https://nozomingway.github.io/ffxiv-trial-title-generator/ogp-image.jpg`

## 修正理由
相対パスではSNSのクローラーが画像にアクセスできないため、GitHub Pagesの絶対URLに変更しました。